### PR TITLE
Fixed typo which produces a dependency warning

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 1.0.0 <5.0.0"
     }
   ],


### PR DESCRIPTION
Hi,
due to a typo the dependency check of "puppetlabs/stdlib" fails right now.
This PR will fix this by simply replacing the "-" with a "/"

Regards,
Matthias