### PR TITLE
Removing funky character from #�Add an arbitrary character to the st…

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -172,7 +172,7 @@ define logrotate::conf (
   }
 
   # Interpolate any variables that might be integers into strings for futer parser compatibility
-  # Add an arbitrary character to the string to stop puppet-lint complaining
+  # Add an arbitrary character to the string to stop puppet-lint complaining
   # Any better ideas greatfully received
   validate_re("X${maxage}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: maxage must be an integer")
   validate_re("X${minsize}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: minsize must match /\\d+[kMG]?/")

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -295,7 +295,7 @@ define logrotate::rule(
   }
 
   # Interpolate any variables that might be integers into strings for futer parser compatibility
-  # Add an arbitrary character to the string to stop puppet-lint complaining
+  # Add an arbitrary character to the string to stop puppet-lint complaining
   # Any better ideas greatfully received
   validate_re("X${maxage}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: maxage must be an integer")
   validate_re("X${minsize}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: minsize must match /\\d+[kMG]?/")


### PR DESCRIPTION
…ring to stop puppet-lint complaining

While running "puppet agent -t ", 
I was getting the below error.
"Error: Could not retrieve catalog from remote server: Error 400 on SERVER: invalid byte sequence in US-ASCII "
for  rule.pp & conf.pp files.
Then i tried to convert them to ISO-8899 format as below

iconv -f UTF-8 -t ISO-8859-1 

I found the funky character in this line "#�Add an arbitrary character to the string to stop puppet-lint complaining
"


