### PR TITLE
Remove hidden Unicode character (0x000A) from comments

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -172,7 +172,7 @@ define logrotate::conf (
   }
 
   # Interpolate any variables that might be integers into strings for futer parser compatibility
-  # Add an arbitrary character to the string to stop puppet-lint complaining
+  # Add an arbitrary character to the string to stop puppet-lint complaining
   # Any better ideas greatfully received
   validate_re("X${maxage}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: maxage must be an integer")
   validate_re("X${minsize}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: minsize must match /\\d+[kMG]?/")

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -295,7 +295,7 @@ define logrotate::rule(
   }
 
   # Interpolate any variables that might be integers into strings for futer parser compatibility
-  # Add an arbitrary character to the string to stop puppet-lint complaining
+  # Add an arbitrary character to the string to stop puppet-lint complaining
   # Any better ideas greatfully received
   validate_re("X${maxage}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: maxage must be an integer")
   validate_re("X${minsize}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: minsize must match /\\d+[kMG]?/")


### PR DESCRIPTION
The space between the hash symbol and 'Add' is a Unicode control symbol
(0x000A). It causes Puppet to fail with "Error: Could not retrieve
catalog from remote server: Error 400 on SERVER: invalid byte sequence
in US-ASCII at /etc/puppet/environments/production/modules/logrotate/manifests/rule.pp:1
on node node01.example.com".

Replace that character by a proper space (0x0020).