### PR TITLE
Add support for maxsize directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ minsize         - The String minimum size a log file must be to be rotated,
                   but not before the scheduled rotation time (optional).
                   The default units are bytes, append k, M or G for kilobytes,
                   megabytes and gigabytes respectively.
+maxsize         - The String maximum size a log file may be to be rotated;
+                  When maxsize is used, both the size and timestamp of a log
+                  file are considered for rotation.
+                  The default units are bytes, append k, M or G for kilobytes,
+                  megabytes and gigabytes respectively.
 missingok       - A Boolean specifying whether logrotate should ignore missing
                   log files or issue an error (optional).
 olddir          - A String path to a directory that rotated logs should be

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -50,6 +50,11 @@
 #                   but not before the scheduled rotation time (optional).
 #                   The default units are bytes, append k, M or G for kilobytes,
 #                   megabytes and gigabytes respectively.
+# maxsize         - The String maximum size a log file may be to be rotated;
+#                   When maxsize is used, both the size and timestamp of a log
+#                   file are considered for rotation.
+#                   The default units are bytes, append k, M or G for kilobytes,
+#                   megabytes and gigabytes respectively.
 # missingok       - A Boolean specifying whether logrotate should ignore missing
 #                   log files or issue an error (optional).
 # olddir          - A String path to a directory that rotated logs should be
@@ -139,6 +144,7 @@ define logrotate::rule(
                         $maillast        = 'undef',
                         $maxage          = 'undef',
                         $minsize         = 'undef',
+                        $maxsize         = 'undef',
                         $missingok       = 'undef',
                         $olddir          = 'undef',
                         $postrotate      = 'undef',
@@ -299,6 +305,7 @@ define logrotate::rule(
   # Any better ideas greatfully received
   validate_re("X${maxage}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: maxage must be an integer")
   validate_re("X${minsize}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: minsize must match /\\d+[kMG]?/")
+  validate_re("X${maxsize}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: maxsize must match /\\d+[kMG]?/")
   validate_re("X${rotate}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: rotate must be an integer")
   validate_re("X${size}", ['^Xundef$', '^X\d+[kMG]?$'], "Logrotate::Conf[${name}]: size must match /\\d+[kMG]?/")
   validate_re("X${shredcycles}", ['^Xundef$', '^X\d+$'], "Logrotate::Conf[${name}]: shredcycles must be an integer")

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -38,7 +38,7 @@
 
   [
     'compresscmd', 'compressext', 'compressoptions', 'dateformat', 'extension',
-    'maxage', 'minsize', 'rotate', 'size', 'shredcycles', 'start',
+    'maxage', 'minsize', 'maxsize', 'rotate', 'size', 'shredcycles', 'start',
     'uncompresscmd'
   ].each do |key|
     value = scope.to_hash[key]


### PR DESCRIPTION
This adds support for the _maxsize_ directive introduced in logrotate version *3.8.1*, which has been released in 2011 (see: https://github.com/logrotate/logrotate/blob/r3-8-1/CHANGES).

relevant section of *man* for logrotate:
__maxsize__ _size_
Log files are rotated when they grow bigger than size bytes even before the additionally specified time interval (daily, weekly, monthly, or yearly).  The related size option is similar except that it is mutually exclusive with the time interval options, and it causes  log  files  to  be  rotated without regard for the last rotation time.  When maxsize is used, both the size and timestamp of a log file are considered.