### PR TITLE
Update Gemfile for Rake/Ruby version dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rake"
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.3') then
+    gem "rake"
+  else
+    gem "rake", "< 11.0.0"
+  end
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.2.0'
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet", '>= 2.1.0'


### PR DESCRIPTION
Latest version of rake (11.x) requires Ruby 1.9.3 or newer, so it will
not work with Ruby 1.8.7