### PR TITLE
Added ability to override default btmp and/or wtmp

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -27,16 +27,20 @@ class logrotate::defaults{
         rotate       => '1',
       }
 
-      logrotate::rule {
-        'wtmp':
-          path        => '/var/log/wtmp',
-          create_mode => '0664',
-          rotate      => '1',
+      if !defined( Logrotate::Rule['wtmp'] ) {
+        logrotate::rule {
+          'wtmp':
+            path        => '/var/log/wtmp',
+            create_mode => '0664',
+        }        
       }
-      logrotate::rule {
+      if !defined( Logrotate::Rule['btmp'] ) {      
+        logrotate::rule {
         'btmp':
           path        => '/var/log/btmp',
           create_mode => '0600',
+          
+        }
       }
     }
     'RedHat': {
@@ -53,16 +57,22 @@ class logrotate::defaults{
         rotate       => '1',
       }
 
-      logrotate::rule {
-        'wtmp':
-          path        => '/var/log/wtmp',
-          create_mode => '0664',
-          missingok   => false,
-          minsize     => '1M';
-        'btmp':
-          path        => '/var/log/btmp',
-          create_mode => '0600',
-          minsize     => '1M';
+      if !defined( Logrotate::Rule['wtmp'] ) {
+        logrotate::rule {
+          'wtmp':
+            path        => '/var/log/wtmp',
+            create_mode => '0664',
+            missingok   => false,
+            minsize     => '1M'
+        }
+      }
+      if !defined( Logrotate::Rule['btmp'] ) {
+        logrotate::rule {
+          'btmp':
+            path        => '/var/log/btmp',
+            create_mode => '0600',
+            minsize     => '1M';
+        }  
       }
     }
     'SuSE': {
@@ -81,15 +91,22 @@ class logrotate::defaults{
         size         => '400k'
       }
 
-      logrotate::rule {
-        'wtmp':
-          path         => '/var/log/wtmp',
-          create_mode  => '0664',
-          missingok    => false;
-        'btmp':
-          path         => '/var/log/btmp',
-          create_mode  => '0600',
-          create_group => 'root';
+      if !defined( Logrotate::Rule['wtmp'] ) {
+        logrotate::rule {
+          'wtmp':
+            path         => '/var/log/wtmp',
+            create_mode  => '0664',
+            missingok    => false;  
+        }  
+      }
+      
+      if !defined( Logrotate::Rule['btmp'] ) {
+        logrotate::rule {
+          'btmp':
+            path         => '/var/log/btmp',
+            create_mode  => '0600',
+            create_group => 'root'            
+        }
       }
     }
     default: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,14 +10,14 @@ class logrotate (
 
   include ::logrotate::install
   include ::logrotate::config
-  include ::logrotate::defaults
   include ::logrotate::rules
+  include ::logrotate::defaults
 
   anchor{'logrotate_begin':}->
   Class['::logrotate::install']->
   Class['::logrotate::config']->
-  Class['::logrotate::defaults']->
   Class['::logrotate::rules']->
+  Class['::logrotate::defaults']->
   anchor{'logrotate_end':}
 
 }

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -1170,5 +1170,40 @@ describe 'logrotate::rule' do
         }.to raise_error(Puppet::Error, /namevar must be alphanumeric/)
       end
     end
+    
+    ###########################################################################
+    # CUSTOM BTMP - Make sure btmp from logrotate::defaults is not being used
+    context 'with a custom btmp' do
+      let(:title) { 'btmp' }
+      let(:params) { 
+        {
+          :path         => '/var/log/btmp',
+          :rotate       => '10',
+          :rotate_every => 'day',
+        }
+      }
+      it do
+        should contain_file('/etc/logrotate.d/btmp') \
+          .with_content(%r{^/var/log/btmp \{\n  daily\n  rotate 10\n\}\n})
+      end
+    end
+
+    ###########################################################################
+    # CUSTOM WTMP - Make sure wtmp from logrotate::defaults is not being used
+    context 'with a custom wtmp' do
+      let(:title) { 'wtmp' }
+      let(:params) { 
+        {
+          :path         => '/var/log/wtmp',
+          :rotate       => '10',
+          :rotate_every => 'day',
+        }
+      }
+      it do
+        should contain_file('/etc/logrotate.d/wtmp') \
+          .with_content(%r{^/var/log/wtmp \{\n  daily\n  rotate 10\n\}\n})
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Ability to define a custom rule for btmp and wtmp and prevent logrotate::defaults class from attempting to define the same rule, causing a duplicate resource declaration error.

Had to re-order to put defaults at the end in order to get things to work properly.

Travis-CI tests for Ruby 1.8.7 will fail due to the latest version of Rake requiring Ruby 1.9.3.  This should be fixed with pull request #19 