### PR TITLE
Interact better with other modules that may want to install logrotate.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,8 +10,18 @@ class logrotate::install{
     default: { $_ensure = 'present' }
   }
 
-  package { $package:
-    ensure => $_ensure,
+  if $_ensure == 'present' {
+    # Make sure that we interact nicely with other modules
+    # that may want to install the logrotate package.
+    ensure_packages($package)
+  } else {
+    # We have some special requirements for this package.
+    # By not using ensure_packages here, we make sure that we
+    # get an error if some other module also tries to
+    # control this package.
+    package { $package:
+      ensure => $_ensure,
+    }
   }
 
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,6 +40,24 @@ describe 'logrotate' do
             should contain_class('logrotate::defaults')
           end
         end
+
+        context 'when other module installs logrotate' do
+          let(:pre_condition) { 'ensure_packages("logrotate")' }
+          it { is_expected.to compile.with_all_deps }
+          it { should contain_package('logrotate').with_ensure('present') }
+        end
+
+        context 'with ensure => latest' do
+          let(:params) { { ensure: 'latest' } }
+          it { is_expected.to compile.with_all_deps }
+          it { should contain_package('logrotate').with_ensure('latest') }
+        end
+
+        context 'when other module installs logrotate and we want to remove it' do
+          let(:params) { { ensure: 'absent' } }
+          let(:pre_condition) { 'package { "logrotate": ensure => present }' }
+          it { is_expected.to raise_error(Puppet::Error, %r{Duplicate declaration}) }
+        end
       end
     end
   end


### PR DESCRIPTION
By using `ensure_packages` from stdlib in the common case, where we just want
to make sure that the logrotate package is installed, we ensure that
we don't get a conflict if a different module also uses `ensure_packages` to
install logrotate.
