### PR TITLE
Fixes #34 - Ubuntu Xenial and up support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
-require 'puppet-strings/rake_tasks'
+require 'puppet-strings/tasks'
 
 if RUBY_VERSION >= '2.3.0'
   require 'rubocop/rake_task'

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -6,15 +6,12 @@ class logrotate::defaults{
     'Debian': {
 
       if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
-        case $::lsbdistcodename {
-          'trusty': {
-            logrotate::conf {'/etc/logrotate.conf':
-              su_group => 'syslog',
-            }
+        if versioncmp($::lsbdistrelease, '14.04') >= 0 {
+          logrotate::conf {'/etc/logrotate.conf':
+            su_group => 'syslog',
           }
-          default: {
-            logrotate::conf {'/etc/logrotate.conf': }
-          }
+        } else {
+          logrotate::conf {'/etc/logrotate.conf': }
         }
       }
 

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -6,7 +6,7 @@ describe 'logrotate::conf' do
       {
         osfamily: 'Debian',
         operatingsystem: 'Debian',
-        lsbdistcodename: 'Imaginary'
+        lsbdistrelease: 'Imaginary'
       }
     end
     context 'with an alphanumeric title' do

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -6,7 +6,7 @@ describe 'logrotate::rule' do
       {
         osfamily: 'Debian',
         operatingsystem: 'Debian',
-        lsbdistcodename: 'Imaginary'
+        lsbdistrelease: 'Imaginary'
       }
     end
     context 'with an alphanumeric title' do


### PR DESCRIPTION
Instead of adding every newer release of Ubuntu, let's assume the su_group will remain the same, until the next change is necessary.