### PR TITLE
use alxwr's pull request in order to run tests

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -210,9 +210,9 @@ define logrotate::conf (
 
   if ($su_user != 'UNDEFINED') and ($su_group == 'UNDEFINED') {
     $_su_user  = $_su_user
-    $_su_group = 'root'
+    $_su_group = $logrotate::root_group
   } elsif ($su_user == 'UNDEFINED') and ($su_group != 'UNDEFINED') {
-    $_su_user  = 'root'
+    $_su_user  = $logrotate::root_user
     $_su_group = $su_group
   } else {
     $_su_user  = $su_user
@@ -238,8 +238,8 @@ define logrotate::conf (
 
   file { $name:
       ensure  => $ensure,
-      owner   => 'root',
-      group   => 'root',
+      owner   => $logrotate::root_user,
+      group   => $logrotate::root_group,
       mode    => '0444',
       content => template('logrotate/etc/logrotate.conf.erb'),
       require => Package['logrotate'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,28 +1,24 @@
 # logrotate config
 class logrotate::config{
 
+  include ::logrotate::params
+
   $manage_cron_daily = $::logrotate::manage_cron_daily
   $config            = $::logrotate::config
 
-  file{'/etc/logrotate.d':
+  file{$logrotate::rules_configdir:
     ensure => directory,
-    owner  => 'root',
-    group  => 'root',
+    owner  => $logrotate::root_user,
+    group  => $logrotate::root_group,
     mode   => '0755',
   }
 
   if $manage_cron_daily {
-    file{'/etc/cron.daily/logrotate':
-      ensure => file,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0555',
-      source => 'puppet:///modules/logrotate/etc/cron.daily/logrotate',
-    }
+    logrotate::cron { 'daily': }
   }
 
   if is_hash($config) {
-    $custom_config = {'/etc/logrotate.conf' => $config}
+    $custom_config = {"${logrotate::logrotate_conf}" => $config}
     create_resources('logrotate::conf', $custom_config)
   }
 

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,0 +1,17 @@
+define logrotate::cron (
+  $ensure = 'present'
+) {
+
+  case $::osfamily {
+    'FreeBSD': { $script_path = "/usr/local/bin/logrotate.${name}.sh" }
+    default: { $script_path = "/etc/cron.${name}/logrotate" }
+  }
+
+  file { $script_path:
+    ensure => $ensure,
+    owner  => $logrotate::root_user,
+    group  => $logrotate::root_group,
+    mode   => '0555',
+    source => "puppet:///modules/logrotate/etc/cron.${name}/logrotate",
+  }
+}

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -2,16 +2,18 @@
 #
 class logrotate::defaults{
 
+  include ::logrotate::params
+
   case $::osfamily {
     'Debian': {
 
-      if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
+      if !defined( Logrotate::Conf[$logrotate::logrotate_conf] ) {
         if versioncmp($::lsbdistrelease, '14.04') >= 0 {
-          logrotate::conf {'/etc/logrotate.conf':
+          logrotate::conf {$logrotate::logrotate_conf:
             su_group => 'syslog',
           }
         } else {
-          logrotate::conf {'/etc/logrotate.conf': }
+          logrotate::conf {$logrotate::logrotate_conf: }
         }
       }
 
@@ -26,8 +28,8 @@ class logrotate::defaults{
 
       if !defined( Logrotate::Rule['wtmp'] ) {
         logrotate::rule { 'wtmp':
-            path        => '/var/log/wtmp',
-            create_mode => '0664',
+          path        => '/var/log/wtmp',
+          create_mode => '0664',
         }
       }
       if !defined( Logrotate::Rule['btmp'] ) {
@@ -38,8 +40,8 @@ class logrotate::defaults{
       }
     }
     'Gentoo': {
-      if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
-        logrotate::conf {'/etc/logrotate.conf':
+      if !defined( Logrotate::Conf[$logrotate::logrotate_conf] ) {
+        logrotate::conf {$logrotate::logrotate_conf:
           dateext  => true,
           compress => true,
           ifempty  => false,
@@ -59,22 +61,22 @@ class logrotate::defaults{
 
       if !defined( Logrotate::Rule['wtmp'] ) {
         logrotate::rule { 'wtmp':
-            path        => '/var/log/wtmp',
-            missingok   => false,
-            create_mode => '0664',
-            minsize     => '1M',
+          path        => '/var/log/wtmp',
+          missingok   => false,
+          create_mode => '0664',
+          minsize     => '1M',
         }
       }
       if !defined( Logrotate::Rule['btmp'] ) {
         logrotate::rule { 'btmp':
-            path        => '/var/log/btmp',
-            create_mode => '0600',
+          path        => '/var/log/btmp',
+          create_mode => '0600',
         }
       }
     }
     'RedHat': {
-      if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
-        logrotate::conf {'/etc/logrotate.conf': }
+      if !defined( Logrotate::Conf[$logrotate::logrotate_conf] ) {
+        logrotate::conf {$logrotate::logrotate_conf: }
       }
 
       Logrotate::Rule {
@@ -88,23 +90,23 @@ class logrotate::defaults{
 
       if !defined( Logrotate::Rule['wtmp'] ) {
         logrotate::rule { 'wtmp':
-            path        => '/var/log/wtmp',
-            create_mode => '0664',
-            missingok   => false,
-            minsize     => '1M',
+          path        => '/var/log/wtmp',
+          create_mode => '0664',
+          missingok   => false,
+          minsize     => '1M',
         }
       }
       if !defined( Logrotate::Rule['btmp'] ) {
         logrotate::rule { 'btmp':
-            path        => '/var/log/btmp',
-            create_mode => '0600',
-            minsize     => '1M',
+          path        => '/var/log/btmp',
+          create_mode => '0600',
+          minsize     => '1M';
         }
       }
     }
     'SuSE': {
-      if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
-        logrotate::conf {'/etc/logrotate.conf': }
+      if !defined( Logrotate::Conf[$logrotate::logrotate_conf] ) {
+        logrotate::conf {$logrotate::logrotate_conf: }
       }
 
       Logrotate::Rule {
@@ -120,23 +122,23 @@ class logrotate::defaults{
 
       if !defined( Logrotate::Rule['wtmp'] ) {
         logrotate::rule { 'wtmp':
-            path        => '/var/log/wtmp',
-            create_mode => '0664',
-            missingok   => false,
+          path        => '/var/log/wtmp',
+          create_mode => '0664',
+          missingok   => false;
         }
       }
 
       if !defined( Logrotate::Rule['btmp'] ) {
         logrotate::rule { 'btmp':
-            path         => '/var/log/btmp',
-            create_mode  => '0600',
-            create_group => 'root',
+          path         => '/var/log/btmp',
+          create_mode  => '0600',
+          create_group => 'root',
         }
       }
     }
     default: {
-      if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
-        logrotate::conf {'/etc/logrotate.conf': }
+      if !defined( Logrotate::Conf[$logrotate::logrotate_conf] ) {
+        logrotate::conf {$logrotate::logrotate_conf: }
       }
     }
   }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -25,18 +25,17 @@ class logrotate::hourly($ensure='present') {
     }
   }
 
-  file { '/etc/logrotate.d/hourly':
-      ensure => $dir_ensure,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0755',
+  file {
+    "${logrotate::rules_configdir}/hourly":
+      ensure  => $dir_ensure,
+      owner   => $logrotate::root_user,
+      group   => $logrotate::root_group,
+      mode    => '0755',
+      require => Package['logrotate'],
   }
-  file { '/etc/cron.hourly/logrotate':
-      ensure  => $ensure,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0555',
-      source  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
-      require => [ File['/etc/logrotate.d/hourly'], Package['logrotate'], ],
+
+  logrotate::cron { 'hourly':
+    ensure  => $ensure,
+    require => File["${logrotate::rules_configdir}/hourly"],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,3 @@
-#
 class logrotate (
   $ensure            = present,
   $hieramerge        = false,
@@ -6,7 +5,12 @@ class logrotate (
   $package           = 'logrotate',
   $rules             = {},
   $config            = undef,
-) {
+  $configdir         = $logrotate::params::configdir,
+  $logrotate_conf    = $logrotate::params::logrotate_conf,
+  $rules_configdir   = $logrotate::params::rules_configdir,
+  $root_user         = $logrotate::params::root_user,
+  $root_group        = $logrotate::params::root_group,
+) inherits ::logrotate::params {
 
   include ::logrotate::install
   include ::logrotate::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,16 @@
+class logrotate::params {
+
+  case $::osfamily {
+    'FreeBSD': { $configdir = '/usr/local/etc' }
+    default: { $configdir = '/etc' }
+  }
+
+  $logrotate_conf = "${configdir}/logrotate.conf"
+  $rules_configdir = "${configdir}/logrotate.d"
+  $root_user = 'root'
+
+  $root_group = $::osfamily ? {
+    'FreeBSD' => 'wheel',
+    default   => 'root',
+  }
+}

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -373,16 +373,16 @@ define logrotate::rule(
   case $rotate_every {
     'hour', 'hourly': {
       include ::logrotate::hourly
-      $rule_path = "/etc/logrotate.d/hourly/${name}"
+      $rule_path = "${logrotate::rules_configdir}/hourly/${name}"
 
-      file { "/etc/logrotate.d/${name}":
+      file { "${logrotate::rules_configdir}/${name}":
         ensure => absent,
       }
     }
     default: {
-      $rule_path = "/etc/logrotate.d/${name}"
+      $rule_path = "${logrotate::rules_configdir}/${name}"
 
-      file { "/etc/logrotate.d/hourly/${name}":
+      file { "${logrotate::rules_configdir}/hourly/${name}":
         ensure => absent,
       }
     }
@@ -390,8 +390,8 @@ define logrotate::rule(
 
   file { $rule_path:
     ensure  => $ensure,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $logrotate::root_user,
+    group   => $logrotate::root_group,
     mode    => '0444',
     content => template('logrotate/etc/logrotate.d/rule.erb'),
     require => Class['::logrotate::config'],

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -65,4 +65,4 @@ endscript
 <% end -%>
 
 # configurable file rotations
-include /etc/logrotate.d
+include <%= @rules_configdir %>


### PR DESCRIPTION
Since I am not able to get the tests running on my local machine (happy if someone could assist me in setting this up). I am trying to use alxwr's pull request on the recent master to be able to let travis run the tests.

I don't care about the Ruby version, but I need that for puppet 3.8.5.
Trying to use  the tests with `ruby 2.2.5`:

```
$ PUPPET_VERSION=3.8.5 bundle exec rake
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
rake aborted!
NameError: uninitialized constant Syck
/home/marius/code/gh/puppet-logrotate/Rakefile:1:in `require'
/home/marius/code/gh/puppet-logrotate/Rakefile:1:in `<top (required)>'
/home/marius/.rbenv/versions/2.2/bin/bundle:23:in `load'
/home/marius/.rbenv/versions/2.2/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```

```
$ PUPPET_VERSION=3.8.5 bundle exec rspec
bundler: failed to load command: rspec (/home/marius/.rbenv/versions/2.2/bin/rspec)
LoadError: cannot load such file -- serverspec
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/beaker-rspec-2.0.0/lib/beaker-rspec/helpers/serverspec.rb:1:in `require'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/beaker-rspec-2.0.0/lib/beaker-rspec/helpers/serverspec.rb:1:in `<top (required)>'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/beaker-rspec-2.0.0/lib/beaker-rspec/spec_helper.rb:2:in `require'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/beaker-rspec-2.0.0/lib/beaker-rspec/spec_helper.rb:2:in `<top (required)>'
  /home/marius/code/gh/puppet-logrotate/spec/spec_helper_acceptance.rb:1:in `require'
  /home/marius/code/gh/puppet-logrotate/spec/spec_helper_acceptance.rb:1:in `<top (required)>'
  /home/marius/code/gh/puppet-logrotate/spec/acceptance/class_spec.rb:1:in `require'
  /home/marius/code/gh/puppet-logrotate/spec/acceptance/class_spec.rb:1:in `<top (required)>'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `each'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:96:in `setup'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:84:in `run'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
  /home/marius/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/rspec-core-3.1.7/exe/rspec:4:in `<top (required)>'
  /home/marius/.rbenv/versions/2.2/bin/rspec:23:in `load'
  /home/marius/.rbenv/versions/2.2/bin/rspec:23:in `<top (required)>'
```

