### PR TITLE
Fix root group for FreeBSD

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -239,7 +239,7 @@ define logrotate::conf (
   file { $name:
       ensure  => $ensure,
       owner   => 'root',
-      group   => 'root',
+      group   => $::logrotate::rootgroup,
       mode    => '0444',
       content => template('logrotate/etc/logrotate.conf.erb'),
       require => Package['logrotate'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,12 +12,25 @@ class logrotate::config{
   }
 
   if $manage_cron_daily {
-    file{'/etc/cron.daily/logrotate':
-      ensure => file,
-      owner  => 'root',
-      group  => $::logrotate::rootgroup,
-      mode   => '0555',
-      source => 'puppet:///modules/logrotate/etc/cron.daily/logrotate',
+    case $::osfamily {
+      'FreeBSD': {
+        # FreeBSD does not have /etc/cron.daily
+        cron { 'logrotate_daily':
+          minute  => '1',
+          hour    => '0',
+          command => '/usr/local/sbin/logrotate /etc/logrotate.conf 2>&1',
+          user    => 'root',
+        }
+      }
+      default: {
+        file{'/etc/cron.daily/logrotate':
+          ensure => file,
+          owner  => 'root',
+          group  => $::logrotate::rootgroup,
+          mode   => '0555',
+          source => 'puppet:///modules/logrotate/etc/cron.daily/logrotate',
+        }
+      }
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@ class logrotate::config{
   file{'/etc/logrotate.d':
     ensure => directory,
     owner  => 'root',
-    group  => 'root',
+    group  => $::logrotate::rootgroup,
     mode   => '0755',
   }
 
@@ -15,7 +15,7 @@ class logrotate::config{
     file{'/etc/cron.daily/logrotate':
       ensure => file,
       owner  => 'root',
-      group  => 'root',
+      group  => $::logrotate::rootgroup,
       mode   => '0555',
       source => 'puppet:///modules/logrotate/etc/cron.daily/logrotate',
     }

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -37,6 +37,35 @@ class logrotate::defaults{
         }
       }
     }
+    'FreeBSD': {
+      if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
+        logrotate::conf {'/etc/logrotate.conf':
+          dateext  => true,
+          compress => true,
+          ifempty  => false,
+          mail     => false,
+          olddir   => false,
+        }
+      }
+
+      Logrotate::Rule {
+        missingok    => true,
+        rotate_every => 'week',
+        create       => true,
+        create_owner => 'root',
+        create_group => 'wheel',
+        rotate       => '5',
+      }
+
+      if !defined( Logrotate::Rule['wtmp'] ) {
+        logrotate::rule { 'wtmp':
+            path        => '/var/log/wtmp',
+            missingok   => false,
+            create_mode => '0664',
+            minsize     => '1M',
+        }
+      }
+    }
     'Gentoo': {
       if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
         logrotate::conf {'/etc/logrotate.conf':

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -13,6 +13,8 @@
 #     ensure => absent,
 #   }
 class logrotate::hourly($ensure='present') {
+  require ::logrotate
+
   case $ensure {
     'absent': {
       $dir_ensure = $ensure
@@ -28,13 +30,13 @@ class logrotate::hourly($ensure='present') {
   file { '/etc/logrotate.d/hourly':
       ensure => $dir_ensure,
       owner  => 'root',
-      group  => 'root',
+      group  => $::logrotate::rootgroup,
       mode   => '0755',
   }
   file { '/etc/cron.hourly/logrotate':
       ensure  => $ensure,
       owner   => 'root',
-      group   => 'root',
+      group   => $::logrotate::rootgroup,
       mode    => '0555',
       source  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
       require => [ File['/etc/logrotate.d/hourly'], Package['logrotate'], ],

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -33,12 +33,26 @@ class logrotate::hourly($ensure='present') {
       group  => $::logrotate::rootgroup,
       mode   => '0755',
   }
-  file { '/etc/cron.hourly/logrotate':
-      ensure  => $ensure,
-      owner   => 'root',
-      group   => $::logrotate::rootgroup,
-      mode    => '0555',
-      source  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
-      require => [ File['/etc/logrotate.d/hourly'], Package['logrotate'], ],
+
+  case $::osfamily {
+    'FreeBSD': {
+      # FreeBSD does not have /etc/cron.hourly
+      cron { 'logrotate_hourly':
+        minute  => '01',
+        hour    => '*',
+        command => '/usr/local/sbin/logrotate /etc/logrotate.d/hourly 2>&1',
+        user    => 'root',
+      }
+    }
+    default: {
+      file { '/etc/cron.hourly/logrotate':
+        ensure  => $ensure,
+        owner   => 'root',
+        group   => $::logrotate::rootgroup,
+        mode    => '0555',
+        source  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
+        require => [ File['/etc/logrotate.d/hourly'], Package['logrotate'], ],
+      }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,15 @@ class logrotate (
   $config            = undef,
 ) {
 
+  case $::osfamily {
+    'FreeBSD': {
+      $rootgroup = 'wheel'
+    }
+    default: {
+      $rootgroup = 'root'
+    }
+  }
+
   include ::logrotate::install
   include ::logrotate::config
   include ::logrotate::rules

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -391,7 +391,7 @@ define logrotate::rule(
   file { $rule_path:
     ensure  => $ensure,
     owner   => 'root',
-    group   => 'root',
+    group   => $::logrotate::rootgroup,
     mode    => '0444',
     content => template('logrotate/etc/logrotate.d/rule.erb'),
     require => Class['::logrotate::config'],

--- a/spec/classes/hourly_spec.rb
+++ b/spec/classes/hourly_spec.rb
@@ -1,41 +1,51 @@
 require 'spec_helper'
 
 describe 'logrotate::hourly' do
-  context 'with default values' do
-    it do
-      should contain_file('/etc/logrotate.d/hourly').with('ensure' => 'directory',
-                                                          'owner'  => 'root',
-                                                          'group'  => 'root',
-                                                          'mode'   => '0755')
-    end
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-    it do
-      should contain_file('/etc/cron.hourly/logrotate').with('ensure' => 'present',
-                                                             'owner'   => 'root',
-                                                             'group'   => 'root',
-                                                             'mode'    => '0555',
-                                                             'source'  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
-                                                             'require' => [
-                                                               'File[/etc/logrotate.d/hourly]',
-                                                               'Package[logrotate]'
-                                                             ])
-    end
-  end
+        context 'with default values' do
+          it do
+            should contain_file('/etc/logrotate.d/hourly').with('ensure' => 'directory',
+                                                                'owner'  => 'root',
+                                                                'group'  => 'root',
+                                                                'mode'   => '0755')
+          end
 
-  context 'with ensure => absent' do
-    let(:params) { { ensure: 'absent' } }
+          it do
+            should contain_file('/etc/cron.hourly/logrotate').with('ensure' => 'present',
+                                                                   'owner'   => 'root',
+                                                                   'group'   => 'root',
+                                                                   'mode'    => '0555',
+                                                                   'source'  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
+                                                                   'require' => [
+                                                                     'File[/etc/logrotate.d/hourly]',
+                                                                     'Package[logrotate]'
+                                                                   ])
+          end
+        end
 
-    it { should contain_file('/etc/logrotate.d/hourly').with_ensure('absent') }
-    it { should contain_file('/etc/cron.hourly/logrotate').with_ensure('absent') }
-  end
+        context 'with ensure => absent' do
+          let(:params) { { ensure: 'absent' } }
 
-  context 'with ensure => foo' do
-    let(:params) { { ensure: 'foo' } }
+          it { should contain_file('/etc/logrotate.d/hourly').with_ensure('absent') }
+          it { should contain_file('/etc/cron.hourly/logrotate').with_ensure('absent') }
+        end
 
-    it do
-      expect do
-        should contain_file('/etc/logrotate.d/hourly')
-      end.to raise_error(Puppet::Error, %r{Invalid ensure value 'foo'})
+        context 'with ensure => foo' do
+          let(:params) { { ensure: 'foo' } }
+
+          it do
+            expect do
+              should contain_file('/etc/logrotate.d/hourly')
+            end.to raise_error(Puppet::Error, %r{Invalid ensure value 'foo'})
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
FreeBSD needs *wheel* to be the root group, so this module would not work correctly until that was accounted for.
